### PR TITLE
fix: package references

### DIFF
--- a/flipside-api/getting-started.md
+++ b/flipside-api/getting-started.md
@@ -23,13 +23,13 @@ pip install flipside
 
 {% tab title="JS/TS/Node SDK" %}
 ```
-yarn add @flipside/sdk
+yarn add @flipsidecrypto/sdk
 ```
 
 _or_
 
 ```
-npm install @flipside/sdk
+npm install @flipsidecrypto/sdk
 ```
 {% endtab %}
 

--- a/flipside-api/key-concepts/run-your-first-query.md
+++ b/flipside-api/key-concepts/run-your-first-query.md
@@ -17,13 +17,13 @@ _Python 3.7 and above, is required to use `flipside`_
 
 {% tab title="JS/TS/Node SDK" %}
 ```
-yarn add @flipside/sdk
+yarn add @flipsidecrypto/sdk
 ```
 
 _or_
 
 ```
-npm install @flipside/sdk
+npm install @flipsidecrypto/sdk
 ```
 {% endtab %}
 


### PR DESCRIPTION
Update our docs which seem to be referencing the wrong package.

https://docs.flipsidecrypto.com/flipside-api/key-concepts/run-your-first-query
<img width="684" alt="image" src="https://github.com/FlipsideCrypto/gitbook/assets/84731260/71cffc26-9b2c-4e20-b5b0-5c5af927c452">
